### PR TITLE
Corrigir os atributos do evento

### DIFF
--- a/app/api/registrar_evento/route.ts
+++ b/app/api/registrar_evento/route.ts
@@ -86,7 +86,10 @@ export async function POST(request: Request) {
     dataHoraInicio,
     undefined,
     payload.descricao,
-    payload.vagasDisponiveis
+    payload.vagasDisponiveis,
+    payload.nome,
+    payload.horarioInicio,
+    payload.horarioFim
   );
 
   const created = await evento.storeOnDb();

--- a/app/lib/Evento.ts
+++ b/app/lib/Evento.ts
@@ -3,7 +3,10 @@ import type { Status } from "@/generated/prisma/enums";
 
 export class Evento {
     public idevento?: number;
+    private readonly nome?: string;
     private readonly data?: Date;
+    private readonly horarioInicio?: string;
+    private readonly horarioFim?: string;
     private readonly endereco?: number;
     private readonly organizador: number;
     private readonly publicado: number;
@@ -18,9 +21,15 @@ export class Evento {
         data?: Date,
         endereco?: number,
         descricao?: string,
-        vagas?: number
+        vagas?: number,
+        nome?: string,
+        horarioInicio?: string,
+        horarioFim?: string
     ) {
+        this.nome = nome;
         this.data = data;
+        this.horarioInicio = horarioInicio;
+        this.horarioFim = horarioFim;
         this.endereco = endereco;
         this.organizador = organizador;
         this.publicado = publicado;
@@ -41,7 +50,10 @@ export class Evento {
         const created = await prisma.evento.create({
             data: {
                 idevento: this.idevento,
+                nome: this.nome,
                 data: this.data,
+                horarioInicio: this.horarioInicio,
+                horarioFim: this.horarioFim,
                 endereco: this.endereco,
                 organizador: this.organizador,
                 publicado: this.publicado,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,7 +30,10 @@ model endere_o {
 
 model evento {
   idevento                                    Int         @id
+  nome                                        String?     @db.VarChar(255)
   data                                        DateTime?   @db.DateTime(0)
+  horarioInicio                               String?     @db.VarChar(5)
+  horarioFim                                  String?     @db.VarChar(5)
   endereco                                    Int?
   organizador                                 Int
   publicado                                   Int         @db.TinyInt


### PR DESCRIPTION
No schema do prisma, o evento não continha as informações de nome ou horário, essa pull request corrige isso, e muda o endpoint para criar o evento com os atributos completos